### PR TITLE
Add support RGB 24-bits input of format_converter

### DIFF
--- a/src/operators/format_converter/format_converter.cpp
+++ b/src/operators/format_converter/format_converter.cpp
@@ -269,6 +269,13 @@ void FormatConverterOp::compute(InputContext& op_input, OutputContext& op_output
         out_shape = nvidia::gxf::Shape{
             static_cast<int32_t>(buffer_info.height), static_cast<int32_t>(buffer_info.width), 4};
         break;
+      case nvidia::gxf::VideoFormat::GXF_VIDEO_FORMAT_RGB:
+        in_primitive_type = nvidia::gxf::PrimitiveType::kUnsigned8;
+        in_channels = 3;  // RGB
+        out_channels = in_channels;
+        out_shape = nvidia::gxf::Shape{
+            static_cast<int32_t>(buffer_info.height), static_cast<int32_t>(buffer_info.width), 3};
+        break;
       case nvidia::gxf::VideoFormat::GXF_VIDEO_FORMAT_NV12:
         in_primitive_type = nvidia::gxf::PrimitiveType::kUnsigned8;
         in_channels = buffer_info.color_planes.size();


### PR DESCRIPTION
I want to add the support the RGB 24-bits input of format_converter.
The default format of our capture card is RGB 24-bits, need this patch to work.
