### PR TITLE
gxf_extentions: fix typo

### DIFF
--- a/gxf_extensions/ucx/ucx_holoscan_component_serializer.cpp
+++ b/gxf_extensions/ucx/ucx_holoscan_component_serializer.cpp
@@ -264,7 +264,7 @@ Expected<size_t> UcxHoloscanComponentSerializer::serializeMessageLabel(
         "%zu bytes. You can try to increase the buffer capacity by setting the "
         "HOLOSCAN_UCX_SERIALIZATION_BUFFER_SIZE environment variable, but the limit it is "
         "possible to set will depend on the maximum header size supported by the underlying "
-        "ucp_send_am_nbx function of UCX.",
+        "ucp_am_send_nbx function of UCX.",
         total_size,
         buffer_capacity);
     return Unexpected{GXF_FAILURE};


### PR DESCRIPTION
<https://github.com/openucx/ucx/blob/9e1c034def4009b57d19cb94a0f8c9c8d2992303/src/ucp/api/ucp.h#L3268>