### PR TITLE
fix(cmake): pass CUDA architectures correctly to get_cmake_cuda_arch.py script

### DIFF
--- a/cmake/modules/SetupCUDA.cmake
+++ b/cmake/modules/SetupCUDA.cmake
@@ -40,10 +40,11 @@ endif()
 if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
     message(STATUS "Using native CUDA architecture detection.")
 else()
+    string(REPLACE ";" "," _holoscan_requested_archs "${CMAKE_CUDA_ARCHITECTURES}")
     # Get the CUDA architectures from the script
     set(_script_command
         "${CMAKE_SOURCE_DIR}/scripts/get_cmake_cuda_archs.py"
-        "${CMAKE_CUDA_ARCHITECTURES}"
+        "${_holoscan_requested_archs}"
         "--nvcc-path" "${CMAKE_CUDA_COMPILER}"
         "--min-arch" "70" # Holoscan requirement
         "--verbose"       # Enable debug logging from script


### PR DESCRIPTION
get_cmake_cuda_arch.py takes a single positional argument, requested_archs. Right now it only accepts either a comma separated list, or a space separated one. However, The way this is set in CMake sometimes looks as follows.

    set(CMAKE_CUDA_ARCHITECTURES "87;110")

Or by using the -D CLI flag. Note that this is a semicolon separated list. The Python script will not parse this correctly when passed as such. The above example would fail to parse with this error.

    unrecognized arguments: 110

Simply replacing ; with , seems like an easy fix.

Ref: https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html#prop_tgt:CUDA_ARCHITECTURES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CUDA architecture configuration handling in the build system to correctly process architecture specifications during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->